### PR TITLE
Fix for player url

### DIFF
--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -79,7 +79,7 @@ class Url implements ToUriInterface
      */
     public function toUri(): UriInterface
     {
-        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/'.$this->media->getPid());
+        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/media/'.$this->media->getPid());
         $query_parts = [];
 
         if ($this->autoplay) {


### PR DESCRIPTION
Same as https://github.com/Lullabot/mpx-php/pull/141 but for 0.6.2 tag.

- The player does not currently play the expected video. The generated iframe says "release with PID was not found; ignoring /select/" for the src"
- Adding /media to the url fixes the issue.
- Our original conversation can be found here for reference --> Lullabot/media_mpx#57
