### PR TITLE
Fix for player url

### DIFF
--- a/src/Player/Url.php
+++ b/src/Player/Url.php
@@ -78,7 +78,7 @@ class Url
      */
     public function toUri(): UriInterface
     {
-        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/'.$this->media->getPid());
+        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/media/'.$this->media->getPid());
         $query_parts = [];
 
         if ($this->autoplay) {


### PR DESCRIPTION
Same as https://github.com/Lullabot/mpx-php/pull/141 but for 0.6.2 tag.

- The player does not currently play the expected video. The generated iframe says "release with PID was not found; ignoring /select/" for the src"
- Adding /media to the url fixes the issue.
- Our original conversation can be found here for reference --> https://github.com/Lullabot/media_mpx/issues/57